### PR TITLE
GAUDISW-247349 [1.24.1][vLLM][G2] RuntimeError: device_allocator INTERNAL ASSERT FAILED at "/npu-stack/pytorch-fork/c10/core/CachingDeviceAllocator.h":116, please report a bug to PyTorch. Allocator for hpu is not a DeviceAllocator.

### DIFF
--- a/c10/core/CachingDeviceAllocator.h
+++ b/c10/core/CachingDeviceAllocator.h
@@ -111,4 +111,12 @@ C10_API inline DeviceAllocator* getDeviceAllocator(const DeviceType& t) {
   return device_allocator;
 }
 
+// Like getDeviceAllocator but returns nullptr if the allocator is not a
+// DeviceAllocator, instead of asserting.
+C10_API inline DeviceAllocator* tryGetDeviceAllocator(
+    const DeviceType& t) {
+  auto* allocator = c10::GetAllocator(t);
+  return dynamic_cast<DeviceAllocator*>(allocator);
+}
+
 } // namespace c10

--- a/torch/csrc/DeviceAccelerator.cpp
+++ b/torch/csrc/DeviceAccelerator.cpp
@@ -75,7 +75,11 @@ void initModule(PyObject* module) {
 
   m.def("_accelerator_isAllocatorInitialized", []() {
     const auto device_type = at::accelerator::getAccelerator(true).value();
-    return at::getDeviceAllocator(device_type)->initialized();
+    auto* device_allocator = c10::tryGetDeviceAllocator(device_type);
+    if (!device_allocator) {
+      return false;
+    }
+    return device_allocator->initialized();
   });
 
   m.def("_accelerator_emptyCache", []() { at::accelerator::emptyCache(); });


### PR DESCRIPTION
Automated implementation for **GAUDISW-247349**.

**Summary:** [1.24.1][vLLM][G2] RuntimeError: device_allocator INTERNAL ASSERT FAILED at "/npu-stack/pytorch-fork/c10/core/CachingDeviceAllocator.h":116, please report a bug to PyTorch. Allocator for hpu is not a DeviceAllocator.

Branch: `dev/sys_qaplatformbot/GAUDISW-247349--20260407103140`